### PR TITLE
add crud book controller and routes, and postman collection

### DIFF
--- a/Challenge_API.postman_collection.json
+++ b/Challenge_API.postman_collection.json
@@ -86,7 +86,7 @@
 				{
 					"name": "delete_author",
 					"request": {
-						"method": "GET",
+						"method": "DELETE",
 						"header": [],
 						"url": {
 							"raw": "{{domain}}/api/authors/07b017a5-1e29-46d6-b3a7-5c09a7ed3c18",
@@ -97,6 +97,93 @@
 								"api",
 								"authors",
 								"07b017a5-1e29-46d6-b3a7-5c09a7ed3c18"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Book",
+			"item": [
+				{
+					"name": "create_book",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"author_id\": \"07b017a5-1e29-46d6-b3a7-5c09a7ed3c18\",\r\n  \"title\": \"The Hobbit\",\r\n  \"genre\": \"Fantasy\",\r\n  \"synopsis\": \"A hobbit embarks on an unexpected journey.\",\r\n  \"publication\": \"1937-09-21\",\r\n  \"isbn\": \"978-0618968633\",\r\n  \"coverImage\": \"https://example.com/thehobbit.jpg\",\r\n  \"pageCount\": 310\r\n}\r\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{domain}}/api/books/new-book",
+							"host": [
+								"{{domain}}"
+							],
+							"path": [
+								"api",
+								"books",
+								"new-book"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "gell_all_books",
+					"request": {
+						"method": "GET",
+						"header": []
+					},
+					"response": []
+				},
+				{
+					"name": "update_book",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"pageCount\": 330\r\n}\r\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{domain}}/api/books/fd272a5b-87ee-450d-8dbb-c3a1a65553fd",
+							"host": [
+								"{{domain}}"
+							],
+							"path": [
+								"api",
+								"books",
+								"fd272a5b-87ee-450d-8dbb-c3a1a65553fd"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "delete_book",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{domain}}/api/books",
+							"host": [
+								"{{domain}}"
+							],
+							"path": [
+								"api",
+								"books"
 							]
 						}
 					},

--- a/src/controllers/crud.book.controller.js
+++ b/src/controllers/crud.book.controller.js
@@ -1,0 +1,125 @@
+import prisma from "../prisma.js";
+
+export const createBook = async(req, res) =>{
+    const { author_id, title, genre, synopsis, publication, isbn, coverImage, pageCount } = req.body;
+
+    if (!author_id && !title && !genre && !publication && !isbn && !pageCount) {
+        return res.status(400).json({ ok: false, message: "No fields to update" });
+    }
+
+    try {
+
+        const existingAuthor = await prisma.author.findUnique({
+            where: { author_id },
+        });
+      
+        if (!existingAuthor) { return res.status(404).json({ ok: false, message: "Author not found" }); }
+
+        const newBook = await prisma.book.create({
+            data: {
+              author_id,
+              title,
+              genre,
+              synopsis: synopsis || null,
+              publication: new Date(publication),
+              isbn,
+              coverImage: coverImage || null,
+              pageCount,
+            },
+        });
+
+        res.status(201).json({ ok: true, message: "Book created successfully", newBook });
+    } catch (error) {
+        console.error("Error creating book:", error);
+        res.status(500).json({ ok: false, message: "Failed to create book" });
+    }
+}
+
+export const getAllBooks = async(req, res) =>{
+    try {
+        const books = await prisma.book.findMany();
+
+        if(books.length === 0){ return res.status(404).json({ ok:false, message: "No books found" }); }
+
+        res.status(200).json({ ok:true, message: books });
+    } catch (error) {
+        console.error("Error fetching books:", error);
+        res.status(500).json({ok: false, message: "Failed to fetch books"});
+    }
+}
+
+export const updateBook = async(req, res) =>{
+    const { book_id } = req.params;
+    const { author_id, title, genre, synopsis, publication, isbn, coverImage, pageCount } = req.body;
+
+    if (!title && !genre && !synopsis && !publication && !isbn && !coverImage && !pageCount) {
+        return res.status(400).json({ ok: false, message: "No fields to update" });
+    }
+
+    try {
+        const existingBook = await prisma.book.findUnique({
+            where: { book_id },
+        });
+      
+        if (!existingBook) { return res.status(404).json({ ok: false, message: "Book not found" }); }
+
+        if (author_id && author_id !== existingBook.author_id) {
+            const existingAuthor = await prisma.author.findUnique({
+              where: { author_id },
+            });
+      
+            if (!existingAuthor) { return res.status(404).json({ ok: false, message: "Author not found" }); }
+        }
+      
+        if (isbn && isbn !== existingBook.isbn) {
+            const duplicateISBN = await prisma.book.findUnique({
+              where: { isbn },
+            });
+      
+            if (duplicateISBN) {
+              return res.status(400).json({ ok: false, message: `A book with this ISBN already exists: ${duplicateISBN.title} (ID: ${duplicateISBN.book_id})`,
+              });
+            }
+        }
+
+        const updatedBook = await prisma.book.update({
+            where: { book_id },
+            data: {
+              author_id: author_id || existingBook.author_id,
+              title: title || existingBook.title,
+              genre: genre || existingBook.genre,
+              synopsis: synopsis || existingBook.synopsis,
+              publication: publication ? new Date(publication) : existingBook.publication,
+              isbn: isbn || existingBook.isbn,
+              coverImage: coverImage || existingBook.coverImage,
+              pageCount: pageCount || existingBook.pageCount,
+            },
+        });
+
+        res.status(201).json({ ok: true, message: "Book updated successfully", updatedBook });
+    } catch (error) {
+        console.error("Error updating book:", error);
+        res.status(500).json({ ok: false, message: "Failed to update book" });
+    }
+}
+
+export const deleteBook = async(req, res) =>{
+    const { book_id } = req.params;
+
+    try {
+        const existingBook = await prisma.book.findUnique({
+            where: { book_id },
+        });
+      
+        if (!existingBook) { return res.status(404).json({ ok: false, message: "Book not found" }); }
+
+        await prisma.book.delete({
+            where: { book_id },
+        });
+
+        res.status(200).json({ ok: true, message: "Book deleted successfully" });
+    } catch (error) {
+        console.error("Error deleting book:", error);
+        res.status(500).json({ ok: false, message: "Failed to delete book" });
+    }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import prisma from "./prisma.js";
 import dotenv from 'dotenv';
 import bodyParser from 'body-parser';
 import authorRoutes from "./routes/crud.author.routes.js"
+import bookRoutes from "./routes/crud.book.routes.js"
 
 const app = express();
 const port = 3000;
@@ -12,6 +13,7 @@ dotenv.config();
 app.use(bodyParser.json());
 
 app.use('/api/authors', authorRoutes);
+app.use('/api/books', bookRoutes)
 
 app.get("/", (req, res)=>{
     res.send("Hello world");

--- a/src/routes/crud.book.routes.js
+++ b/src/routes/crud.book.routes.js
@@ -1,0 +1,11 @@
+import express from "express";
+import { createBook, getAllBooks, updateBook, deleteBook } from "../controllers/crud.book.controller.js";
+
+const router = express.Router();
+
+router.post("/new-book", createBook);
+router.get("/", getAllBooks);
+router.put("/:book_id", updateBook);
+router.delete("/:book_id", deleteBook);
+
+export default router;


### PR DESCRIPTION
## ¿Qué tipo de PR es este?
- [x] Funcionalidad


## Descripción
Se implementó un controlador para gestionar las operaciones CRUD de libros, junto con sus respectivas rutas.

## **Cambios Realizados**

1. Creación de controlador:
   - Implementación de los métodos necesarios para realizar operaciones CRUD en la entidad Book (crear, leer, actualizar y eliminar).

2. Colección de postam:
   - Se creó una colección de Postman que incluye las solicitudes necesarias para probar todas las rutas de la API relacionadas con la gestión de libros.